### PR TITLE
Added support of single configuration object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travix-acl-middleware",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Travix ACL middleware",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/acl.js
+++ b/src/acl.js
@@ -5,12 +5,16 @@ import { FORBIDDEN, X_FORWARDED_FOR_HEADER } from './constants';
  * Produces an ACL middleware component.
  *
  * @param  {Object}          [options]                 options object
+ * @param  {Object}          [options.allow]           predefined set of permissive rules: "*" or array of [resource, cidr] pairs where resource and cidr can be arrays
  * @param  {Function}        [options.configure]       a function that accepts a context and uses it to configure the rules
+ * @param  {Object}          [options.deny]            predefined set of restrictive rules: "*" or array of [resource, cidr] pairs where resource and cidr can be arrays
  * @param  {Number|Function} [options.respondWith]     either a function that returns an http status code or a number literal representing the status code; default: 403
  * @param  {handleResponse}  [options.handleResponse]  a function to handle an forbidden request
  * @return {Function}   ACL middleware
  */
 export default function acl(options) {
+  const ctx = new Context(options);
+
   const {
     configure = function configure() { },
     respondWith = FORBIDDEN,
@@ -20,7 +24,6 @@ export default function acl(options) {
     }
   } = options;
 
-  const ctx = new Context();
   configure(ctx);
   const isAllowed = ctx.build();
 

--- a/test/context.spec.js
+++ b/test/context.spec.js
@@ -94,19 +94,36 @@ describe('context', () => {
     });
   });
 
-  it('should deny all with deny all rule access to a single resource', () => {
+  it('should be able to add rules from config', () => {
+    expect(() => new Context({
+      allow: [
+        ['/protected/resource/1', '*'],
+        ['*', '127.0.0.1/32'],
+        [['/protected/resource/2', '/protected/resource/3'], '192.168.0.0/24'],
+        ['/protected/resource/4', ['192.168.0.0/24', '192.168.1.0/24']]
+      ],
+      deny: '*'
+    })).not.to.throw(Error);
+  });
+
+  it('should fail if config is malformed', () => {
+    expect(() => new Context({ allow: {} })).to.throw(Error);
+    expect(() => new Context({ allow: [{}] })).to.throw(Error);
+  });
+
+  it('should deny access to some resource', () => {
     const isAllowed = context.forResource('/path').deny('*').build();
     const allowed = isAllowed('/path', ip.address());
     expect(allowed).to.be.false;
   });
 
-  it('should deny all with deny all rule access to subset of resources', () => {
+  it('should deny access subset of resources', () => {
     const isAllowed = context.forResource('/path/*').deny('*').build();
     expect(isAllowed('/path/1', ip.address())).to.be.false;
     expect(isAllowed('/path/1/2', ip.address())).to.be.false;
   });
 
-  it('should allow all addresses of given ranges access to a single resource', () => {
+  it('should allow access to some resource for all addresses of given ranges', () => {
     const allowedRanges = ['192.168.0.1/24', '172.10.154.100/25', '127.0.0.1/32'];
     context.forResource('/path').deny('*');
     allowedRanges.forEach((range) => {
@@ -122,7 +139,7 @@ describe('context', () => {
     });
   });
 
-  it('should allow all addresses of given ranges access to subset of resources', () => {
+  it('should allow access to subset of resources for all addresses of given ranges', () => {
     const allowedRanges = ['192.168.0.1/24', '172.10.154.100/25', '127.0.0.1/32'];
     context.forResource('/path/*').deny('*');
     allowedRanges.forEach((range) => {
@@ -139,7 +156,7 @@ describe('context', () => {
     });
   });
 
-  it('should deny all addresses of given ranges access to a single resource', () => {
+  it('should deny access to some resource for all addresses of given ranges', () => {
     const allowedRanges = ['192.168.0.1/24', '172.10.154.100/25', '127.0.0.1/32'];
     context.forResource('/path').allow('*');
     allowedRanges.forEach((range) => {
@@ -155,7 +172,7 @@ describe('context', () => {
     });
   });
 
-  it('should deny all addresses of given ranges access to subset of resources', () => {
+  it('should deny access to subset of resources for all addresses of given ranges', () => {
     const allowedRanges = ['192.168.0.1/24', '172.10.154.100/25', '127.0.0.1/32'];
     context.forResource('/path/*').allow('*');
     allowedRanges.forEach((range) => {
@@ -172,7 +189,7 @@ describe('context', () => {
     });
   });
 
-  it('should allow multiple nested ranges access to a single resource', () => {
+  it('should allow access to some resource for multiple nested ranges', () => {
     const isAllowed = context
       .forResource('/path')
       .deny('*')
@@ -186,7 +203,7 @@ describe('context', () => {
     expect(isAllowed('/path', '192.168.0.254')).to.be.true;
   });
 
-  it('should allow multiple nested ranges access to subset of resources', () => {
+  it('should allow access to subset of resources for multiple nested ranges', () => {
     const isAllowed = context
       .forResource('/path/*')
       .deny('*')


### PR DESCRIPTION
**What does this PR do:**
Extends functionality of the middleware to support predefined "allow" and "deny" sections in the options object for config-based rule sets.

**Where should the reviewer start:**
Diffs.

**Unit and/or functional tests:**
Updated, pass.